### PR TITLE
textareaの中身を消す

### DIFF
--- a/views/post/index.html
+++ b/views/post/index.html
@@ -8,8 +8,7 @@
 	<form action="/post/create" method="post" accept-charset="utf-8">
 		<div class="form-group">
 			<label>Content</label>
-			<textarea name="content" class="form-control" required="required">
-			</textarea>
+			<textarea name="content" class="form-control" required="required"></textarea>
 		</div>
 		<input class="btn btn-primary" type="submit" value="Post"/>
 	</form>


### PR DESCRIPTION
textareaのタグ内に半角スペースを入れるとデフォルトで入ってしまいます。
